### PR TITLE
Harden PTY child-process setup with error checks and safer fd limits

### DIFF
--- a/crates/pu-engine/src/pty_manager.rs
+++ b/crates/pu-engine/src/pty_manager.rs
@@ -141,7 +141,7 @@ impl NativePtyHost {
                     // other PTY fds, and tokio internals into the child.
                     let max_fd = libc::sysconf(libc::_SC_OPEN_MAX);
                     let upper = if max_fd > 3 && max_fd <= i32::MAX as libc::c_long {
-                        max_fd as i32
+                        core::cmp::min(max_fd as i32, FD_CLOSE_UPPER_BOUND)
                     } else {
                         FD_CLOSE_UPPER_BOUND
                     };


### PR DESCRIPTION
## Summary

- **Error checking**: `setsid()`, `ioctl(TIOCSCTTY)`, and `chdir()` now call `_exit(1)` on failure instead of silently continuing in a broken state
- **Safer fd-close upper bound**: Fixed `sysconf(_SC_OPEN_MAX)` overflow into `i32` and raised fallback cap from 1024 to 10240 via `FD_CLOSE_UPPER_BOUND` constant
- **No behavioral change** for the happy path — only affects error/edge cases

## Test plan

- [ ] Launch workspace agents and verify terminal sessions start correctly
- [ ] Verify no fd leaks by checking child process `/dev/fd` after spawn
- [ ] Test with invalid cwd to confirm child exits cleanly instead of hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PTY sessions now support configurable working directory, environment variables, and terminal window dimensions.

* **Bug Fixes**
  * Strengthened error handling for critical PTY setup operations that previously continued on failure.
  * Enhanced file descriptor cleanup with adaptive resource limits for improved robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->