### PR TITLE
Hide SwiftTerm cursor for all agents

### DIFF
--- a/apps/purepoint-macos/purepoint-macos/Views/Terminal/TerminalPaneView.swift
+++ b/apps/purepoint-macos/purepoint-macos/Views/Terminal/TerminalPaneView.swift
@@ -56,6 +56,7 @@ class TerminalPaneNSView: NSView {
             tv.trailingAnchor.constraint(equalTo: trailingAnchor),
             tv.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
+        tv.terminalView.hideCursor(source: tv.terminalView.getTerminal())
         terminal = tv
     }
 


### PR DESCRIPTION
## Summary

- Hide SwiftTerm's built-in `CaretView` cursor for all agent terminals using `hideCursor(source:)` API
- Agents manage their own TUI cursors — the SwiftTerm caret was visual noise below the agent's interface
- Single-line fix in `ensureTerminal()`, no agent-type checks needed

## Test plan

- [ ] Build the macOS app in Xcode
- [ ] Spawn a claude agent — no blinking cursor below claude's TUI
- [ ] Spawn a terminal agent — no extra cursor (terminal apps render their own via escape sequences)
- [ ] Switch between agents — cursor should not reappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal cursor is now automatically hidden after setup for a cleaner user interface appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->