### PR TITLE
Fix terminal spawning at wrong width

### DIFF
--- a/apps/purepoint-macos/purepoint-macos/Services/DaemonAttachSession.swift
+++ b/apps/purepoint-macos/purepoint-macos/Services/DaemonAttachSession.swift
@@ -89,6 +89,21 @@ actor DaemonAttachSession {
             throw DaemonAttachError.unexpectedResponse
         }
 
+        // Send initial resize so PTY matches the terminal view's actual dimensions.
+        // The sizeChanged delegate fires during terminal creation (before connection
+        // exists), so this is the first opportunity to sync the PTY size.
+        let (initialCols, initialRows) = await MainActor.run {
+            guard let tv else { return (0, 0) }
+            let term = tv.getTerminal()
+            return (term.cols, term.rows)
+        }
+        if initialCols > 0 && initialRows > 0 {
+            try await DaemonClient.write(
+                .resize(agentId: agentId, cols: initialCols, rows: initialRows),
+                to: conn
+            )
+        }
+
         // Stream loop
         while !stopped {
             let line = try await reader.readLine()


### PR DESCRIPTION
## Summary

- Sends an initial PTY resize message immediately after the attach connection is established in `DaemonAttachSession.runAttachLoop()`
- The daemon spawns PTYs at a hardcoded 120x40, but SwiftTerm's `sizeChanged` delegate fires during terminal creation before the connection exists, so the resize was silently dropped
- Now reads the terminal's actual cols/rows via `MainActor` and sends a `.resize` message after receiving `AttachReady`, before the stream loop begins

## Test plan

- [ ] Spawn a new agent — terminal should immediately fill the full window width
- [ ] Resize window — terminal should reflow correctly
- [ ] Split into grid mode — both panes should have correct width
- [ ] Close a pane (2→1) — surviving terminal should fill full width
- [ ] Switch between agents — terminals should have correct width on re-attach

🤖 Generated with [Claude Code](https://claude.com/claude-code)