### PR TITLE
Replace stringly-typed AgentEntry.status with AgentStatus enum

### DIFF
--- a/apps/purepoint-macos/purepoint-macos/Models/ManifestModel.swift
+++ b/apps/purepoint-macos/purepoint-macos/Models/ManifestModel.swift
@@ -55,7 +55,7 @@ nonisolated struct AgentEntry: Codable, Sendable {
     let id: String
     let name: String
     let agentType: String
-    let status: String
+    let status: AgentStatus
     let prompt: String?
     let startedAt: String
     let completedAt: String?

--- a/apps/purepoint-macos/purepoint-macos/Models/WorkspaceModel.swift
+++ b/apps/purepoint-macos/purepoint-macos/Models/WorkspaceModel.swift
@@ -43,7 +43,7 @@ nonisolated struct AgentModel: Identifiable, Equatable, Sendable {
             id: entry.id,
             name: entry.name,
             agentType: entry.agentType,
-            status: AgentStatus(rawValue: entry.status) ?? .lost,
+            status: entry.status,
             prompt: entry.prompt ?? "",
             startedAt: entry.startedAt,
             sessionId: entry.sessionId,


### PR DESCRIPTION
## Summary

- Change `AgentEntry.status` from `String` to `AgentStatus` so the JSON decoder fails explicitly on unknown values instead of silently falling back to `.lost`
- Remove manual `AgentStatus(rawValue:) ?? .lost` conversion in `AgentModel(from:)` since the type is now `AgentStatus` directly

Closes #70

## Test plan

- [x] Verified `xcodebuild build` succeeds with no new warnings or errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)