### PR TITLE
Restructure README as narrative story with inline screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,33 +17,58 @@ In basketball, a pure point guard doesn't score — they read the court, call th
 
 Unlike headless agent swarms where you prompt-and-forget, PurePoint gives you workspaces you **coach**. You see every terminal. You step in, redirect, course-correct. The UI is designed like productivity software — think of agents as collaborators, not background jobs.
 
-## How It Works
+## Build Your Team
 
-PurePoint has two mental models:
+Define reusable agent types — a PR reviewer, a security auditor, a refactorer. Each gets a name, a system prompt, and tags. Build your roster once, deploy it everywhere.
 
-**Workstations** are persistent. You spawn agents, direct their work, and work alongside them. Three agents reviewing the same PR from different angles — one command, three panes, three perspectives on one worktree.
+![Agent definitions in the Agents Hub](docs/images/agents-screen.png)
 
-**Exploratory swarms** are transient. Spawn 20 agents with the same greenfield prompt, let them each take a different approach, then compare results. You use the information, not necessarily the code. Ten agents each fixing a different issue — one swarm, ten worktrees, ten branches, all in parallel.
+## Call the Play
+
+Assemble agents into swarms — named plays. A `pr-review` swarm with 3 reviewers on 1 worktree, or a `simplify` swarm with 7 agents across 7 worktrees. Define the roster, set the execution config, and hit Run.
 
 ![Swarm definition with roster and execution config](docs/images/swarm-screen.png)
 
-## Features
+## Watch the Game
 
-- **Pane grid** — split your workspace into any arrangement of terminal panes, each showing a live agent
-- **Diff viewer** — review unstaged changes and PR diffs across worktrees without leaving the app
-- **Swarms** — named plays defining which agents run, what prompts they get, and how worktrees are allocated
-- **Prompt templates** — reusable prompts with variable substitution that resolve at spawn time
-- **Agent definitions** — save custom agent configurations with specific types, prompts, and tags
+All agents stream live in the sidebar. Click any worktree to watch its terminal. Every agent visible, every branch isolated.
+
+PurePoint has two mental models. **Workstations** are persistent — you spawn agents, direct their work, and work alongside them. Three agents reviewing the same PR from different angles, three panes, three perspectives. **Exploratory swarms** are transient — spawn 20 agents with the same greenfield prompt, let them each take a different approach, then compare results. You use the information, not necessarily the code.
+
+## Coach the Players
+
+Point Guard is your conversational interface. Ask it to spawn agents, check status, redirect work — without leaving the chat.
+
+![Point Guard — fresh conversation](docs/images/point-guard-agent.png)
+
+Ask a question and Point Guard calls tools on your behalf, orchestrating agents and reporting back with results.
+
+![Point Guard conversation with tool calls](docs/images/past-convo-view.png)
+
+## Review the Results
+
+When agents finish, review their work without leaving PurePoint. The diff viewer shows unstaged changes and PR diffs per worktree — modified files highlighted, changes inline.
+
+![Diff viewer with PR changes](docs/images/diff-viewer.png)
+
+## Automate the Routine
+
+Schedule swarms to run on a cadence. A nightly security review, a weekly dependency audit — results waiting when you open the app.
+
+![Weekly schedule calendar](docs/images/weekly-cal-schedule.png)
+
+## Make It Yours
+
+Rebind every action. Navigate without a mouse. The settings panel lets you customize hotkeys for all workspace actions and navigation.
+
+![Customizable hotkeys settings](docs/images/hotkeys-menu.png)
+
+## And More
+
+- **Pane grid** — split your workspace into any arrangement of terminal panes
 - **Command palette** — keyboard-driven control over your entire workspace
-- **Customizable hotkeys** — rebind every action; navigate without a mouse
-- **Point Guard chat** — conversational interface for directing work across your workspace
+- **Prompt templates** — reusable prompts with variable substitution, resolved at spawn time
 - **Auto-resume** — agents and layout persist across app restarts
-- **Schedules** — swarms on cron; a nightly security review or weekly dependency audit, results waiting when you open the app
-
-| ![Agent definitions](docs/images/agents-screen.png) | ![Diff viewer](docs/images/diff-viewer.png) |
-|---|---|
-| ![Point Guard chat](docs/images/past-convo-view.png) | ![Customizable hotkeys](docs/images/hotkeys-menu.png) |
-| ![Weekly schedule](docs/images/weekly-cal-schedule.png) | ![Point Guard](docs/images/point-guard-agent.png) |
 
 ## Getting Started
 


### PR DESCRIPTION
## Summary
- Replace feature-grid table and bullet list with story-driven sections that walk the reader through using PurePoint
- Each of the 8 screenshots is now placed inline with narrative context: Build Your Team, Call the Play, Watch the Game, Coach the Players, Review the Results, Automate the Routine, Make It Yours
- Add "And More" section for features without dedicated screenshots (pane grid, command palette, prompt templates, auto-resume)
- All other sections (The Idea, Getting Started, CLI reference, Current Status, Building from Source, License) unchanged

## Test plan
- [ ] Verify README renders correctly on GitHub (all 8 images load, no broken links)
- [ ] Read top-to-bottom for narrative flow
- [ ] Confirm no duplicate images and all paths are correct relative references

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized README with new narrative sections featuring visual elements and comprehensive descriptions
  * Enhanced feature explanations covering agent definitions, swarms, workstations, and interactive tools
  * Updated documentation to better emphasize real-time streaming, live terminal capabilities, and multi-agent orchestration
  * Improved overall content structure and flow for enhanced user understanding and feature discovery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->