### PR TITLE
Remove obsolete Default Agent and Project Directory settings

### DIFF
--- a/apps/purepoint-macos/purepoint-macos/State/SettingsState.swift
+++ b/apps/purepoint-macos/purepoint-macos/State/SettingsState.swift
@@ -29,14 +29,6 @@ enum AppAppearance: String, CaseIterable {
 final class SettingsState {
     // MARK: - General
 
-    var defaultAgentVariant: String = "claude" {
-        didSet { UserDefaults.standard.set(defaultAgentVariant, forKey: "PP_defaultAgentVariant") }
-    }
-
-    var defaultProjectDirectory: String = "~" {
-        didSet { UserDefaults.standard.set(defaultProjectDirectory, forKey: "PP_defaultProjectDirectory") }
-    }
-
     var restoreProjectsOnLaunch: Bool = true {
         didSet { UserDefaults.standard.set(restoreProjectsOnLaunch, forKey: "PP_restoreProjectsOnLaunch") }
     }
@@ -64,12 +56,6 @@ final class SettingsState {
     init() {
         let defaults = UserDefaults.standard
 
-        if let v = defaults.string(forKey: "PP_defaultAgentVariant") {
-            defaultAgentVariant = v
-        }
-        if let v = defaults.string(forKey: "PP_defaultProjectDirectory") {
-            defaultProjectDirectory = v
-        }
         if defaults.object(forKey: "PP_restoreProjectsOnLaunch") != nil {
             restoreProjectsOnLaunch = defaults.bool(forKey: "PP_restoreProjectsOnLaunch")
         }

--- a/apps/purepoint-macos/purepoint-macos/Views/Settings/SettingsGeneralView.swift
+++ b/apps/purepoint-macos/purepoint-macos/Views/Settings/SettingsGeneralView.swift
@@ -11,36 +11,6 @@ struct SettingsGeneralView: View {
                 .font(.system(size: 18, weight: .semibold))
 
             GroupBox {
-                LabeledContent("Default Agent") {
-                    Picker("", selection: $settings.defaultAgentVariant) {
-                        ForEach(AgentVariant.allVariants) { variant in
-                            Text(variant.displayName).tag(variant.id)
-                        }
-                    }
-                    .labelsHidden()
-                    .frame(width: 160)
-                }
-                .padding(.vertical, 8)
-
-                Divider()
-
-                LabeledContent("Project Directory") {
-                    HStack(spacing: 8) {
-                        Text(settings.defaultProjectDirectory)
-                            .font(.system(size: 12, design: .monospaced))
-                            .foregroundStyle(.secondary)
-                            .lineLimit(1)
-                            .truncationMode(.middle)
-
-                        Button("Choose\u{2026}") {
-                            chooseDirectory()
-                        }
-                    }
-                }
-                .padding(.vertical, 8)
-
-                Divider()
-
                 Toggle("Restore projects on launch", isOn: $settings.restoreProjectsOnLaunch)
                     .padding(.vertical, 8)
 
@@ -50,18 +20,6 @@ struct SettingsGeneralView: View {
                     .padding(.vertical, 8)
             }
             .groupBoxStyle(SettingsGroupBoxStyle())
-        }
-    }
-
-    private func chooseDirectory() {
-        let panel = NSOpenPanel()
-        panel.canChooseDirectories = true
-        panel.canChooseFiles = false
-        panel.allowsMultipleSelection = false
-        panel.message = "Choose default project directory"
-
-        if panel.runModal() == .OK, let url = panel.url {
-            settingsState.defaultProjectDirectory = url.path
         }
     }
 }


### PR DESCRIPTION
## Summary
- Remove `defaultAgentVariant` and `defaultProjectDirectory` properties from `SettingsState`
- Remove Default Agent picker and Project Directory chooser from Settings General view

## Test plan
- [ ] Open Settings → General tab → Default Agent and Project Directory sections are gone
- [ ] Remaining settings (Restore projects, Launch at login) still work
- [ ] Xcode build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Settings Changes**
  * Removed Default Agent Variant configuration from preferences
  * Removed Default Project Directory selection from General settings
  * Streamlined settings interface to focus on essential options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->