### PR TITLE
fix: Remove overlays blocking scroll in split panes

### DIFF
--- a/apps/purepoint-macos/purepoint-macos/Views/PaneGrid/PaneCellView.swift
+++ b/apps/purepoint-macos/purepoint-macos/Views/PaneGrid/PaneCellView.swift
@@ -1,34 +1,76 @@
 import SwiftUI
 
 /// A single pane cell in the grid — shows a terminal or empty placeholder.
+/// Hover detection lives on the outer ZStack (backed by the opaque terminal),
+/// so the overlay never intercepts clicks meant for the terminal.
 struct PaneCellView: View {
     let leafId: Int
     let agentId: String?
     let isFocused: Bool
+    @State private var isHovered = false
     @Environment(AppState.self) private var appState
     @Environment(GridState.self) private var gridState
 
     var body: some View {
-        ZStack(alignment: .top) {
+        ZStack(alignment: .topTrailing) {
             if let agentId, let agent = appState.agent(byId: agentId) {
-                TerminalContainerView(agent: agent, isFocused: isFocused)
+                TerminalContainerView(
+                    agent: agent,
+                    isFocused: isFocused,
+                    onFocus: { gridState.focusedLeafId = leafId }
+                )
             } else {
                 PanePlaceholderView(leafId: leafId)
+                    .onTapGesture {
+                        gridState.focusedLeafId = leafId
+                    }
             }
 
             // Focus indicator bar
             if isFocused {
-                Rectangle()
-                    .fill(Color.accentColor)
-                    .frame(height: 2)
+                VStack {
+                    Rectangle()
+                        .fill(Color.accentColor)
+                        .frame(height: 2)
+                    Spacer()
+                }
+                .allowsHitTesting(false)
             }
 
-            // Hover overlay with split/close buttons
-            HoverOverlay(leafId: leafId)
+            // Hover buttons (split/close)
+            if isHovered {
+                HStack(spacing: 4) {
+                    if gridState.canSplit(axis: .vertical) {
+                        OverlayButton(icon: "rectangle.split.2x1", tooltip: "Split Right") {
+                            gridState.focusedLeafId = leafId
+                            gridState.splitFocused(axis: .vertical)
+                            gridState.pendingPaletteLeafId = gridState.focusedLeafId
+                        }
+                    }
+                    if gridState.canSplit(axis: .horizontal) {
+                        OverlayButton(icon: "rectangle.split.1x2", tooltip: "Split Below") {
+                            gridState.focusedLeafId = leafId
+                            gridState.splitFocused(axis: .horizontal)
+                            gridState.pendingPaletteLeafId = gridState.focusedLeafId
+                        }
+                    }
+                    if gridState.leafCount > 1 {
+                        OverlayButton(icon: "xmark", tooltip: "Close Pane") {
+                            gridState.focusedLeafId = leafId
+                            gridState.closeFocused()
+                        }
+                    }
+                }
+                .padding(6)
+                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 6))
+                .padding(8)
+                .transition(.opacity.animation(.easeInOut(duration: 0.2)))
+            }
         }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            gridState.focusedLeafId = leafId
+        .onHover { hovering in
+            withAnimation(.easeInOut(duration: 0.2).delay(hovering ? 0 : 0.3)) {
+                isHovered = hovering
+            }
         }
     }
 }
@@ -91,55 +133,6 @@ private struct PanePlaceholderView: View {
                     agent: def.agentType, prompt: prompt ?? def.inlinePrompt ?? "", leafId: lid, gridState: gs)
             case .runSwarm:
                 break
-            }
-        }
-    }
-}
-
-/// Hover overlay showing split/close buttons in the top-right corner.
-private struct HoverOverlay: View {
-    let leafId: Int
-    @State private var isHovered = false
-    @Environment(GridState.self) private var gridState
-
-    var body: some View {
-        ZStack(alignment: .topTrailing) {
-            Color.clear
-
-            if isHovered {
-                HStack(spacing: 4) {
-                    if gridState.canSplit(axis: .vertical) {
-                        OverlayButton(icon: "rectangle.split.2x1", tooltip: "Split Right") {
-                            gridState.focusedLeafId = leafId
-                            gridState.splitFocused(axis: .vertical)
-                            gridState.pendingPaletteLeafId = gridState.focusedLeafId
-                        }
-                    }
-                    if gridState.canSplit(axis: .horizontal) {
-                        OverlayButton(icon: "rectangle.split.1x2", tooltip: "Split Below") {
-                            gridState.focusedLeafId = leafId
-                            gridState.splitFocused(axis: .horizontal)
-                            gridState.pendingPaletteLeafId = gridState.focusedLeafId
-                        }
-                    }
-                    if gridState.leafCount > 1 {
-                        OverlayButton(icon: "xmark", tooltip: "Close Pane") {
-                            gridState.focusedLeafId = leafId
-                            gridState.closeFocused()
-                        }
-                    }
-                }
-                .padding(6)
-                .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 6))
-                .padding(8)
-                .transition(.opacity.animation(.easeInOut(duration: 0.2)))
-            }
-        }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .contentShape(Rectangle())
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.2).delay(hovering ? 0 : 0.3)) {
-                isHovered = hovering
             }
         }
     }

--- a/apps/purepoint-macos/purepoint-macos/Views/Terminal/TerminalContainerView.swift
+++ b/apps/purepoint-macos/purepoint-macos/Views/Terminal/TerminalContainerView.swift
@@ -4,6 +4,7 @@ import SwiftUI
 struct TerminalContainerView: NSViewRepresentable {
     let agent: AgentModel
     var isFocused: Bool = false
+    var onFocus: (() -> Void)? = nil
     @Environment(TerminalViewCache.self) private var viewCache
 
     func makeNSView(context: Context) -> NSView {
@@ -12,6 +13,7 @@ struct TerminalContainerView: NSViewRepresentable {
         container.layer?.backgroundColor = TerminalTheme.background.cgColor
 
         let termView = viewCache.terminalView(for: agent)
+        termView.onMouseDown = onFocus
         termView.isHidden = false
         termView.pinToEdges(of: container)
 
@@ -20,6 +22,7 @@ struct TerminalContainerView: NSViewRepresentable {
 
     func updateNSView(_ nsView: NSView, context: Context) {
         let termView = viewCache.terminalView(for: agent)
+        termView.onMouseDown = onFocus
 
         // Already showing the correct agent — just ensure focus
         if termView.superview === nsView && !termView.isHidden {

--- a/apps/purepoint-macos/purepoint-macos/Views/Terminal/TerminalPaneView.swift
+++ b/apps/purepoint-macos/purepoint-macos/Views/Terminal/TerminalPaneView.swift
@@ -24,6 +24,7 @@ struct TerminalPaneView: NSViewRepresentable {
 /// The AppKit view that wraps a ScrollableTerminal and manages daemon attach lifecycle.
 class TerminalPaneNSView: NSView {
     let agent: AgentModel
+    var onMouseDown: (() -> Void)?
     private(set) var terminal: ScrollableTerminal?
     private var attachTask: Task<Void, Never>?
     private var attachStarted = false
@@ -144,6 +145,7 @@ class TerminalPaneNSView: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
+        onMouseDown?()
         focusTerminal()
         super.mouseDown(with: event)
     }


### PR DESCRIPTION
## Summary

- **Root cause**: `PaneCellView` layered hit-intercepting SwiftUI views (`HoverOverlay` with `Color.clear` + `.contentShape(Rectangle())`, and `.onTapGesture` on the outer ZStack) on top of the terminal NSView, blocking all scroll events and scrollbar interaction in split pane mode
- **Fix**: Restructured `PaneCellView` to follow the working `AgentTerminalPane` pattern — `.onHover` directly on the ZStack, inline hover buttons (no full-pane content shape), focus indicator with `.allowsHitTesting(false)`, and tap-to-focus moved into the AppKit layer via `onMouseDown` callback
- **Files changed**: `PaneCellView.swift` (restructured, removed `HoverOverlay`), `TerminalPaneView.swift` (added `onMouseDown` callback), `TerminalContainerView.swift` (wired `onFocus` through to AppKit)

## Test plan

- [ ] Build and run the app
- [ ] Open a workspace with running agents
- [ ] Enter grid mode (split into 2+ panes)
- [ ] **Scroll wheel**: verify scroll works in each pane (both normal scrollback and in programs like `less`/`vim`)
- [ ] **Scrollbar**: verify the scrollbar responds to clicks and drags
- [ ] **Tap-to-focus**: verify clicking a non-focused pane focuses it (accent bar moves)
- [ ] **Hover buttons**: verify split/close buttons appear on hover and are clickable
- [ ] **Single pane**: verify single-pane mode (non-grid) still works
- [ ] **Pane close**: verify closing a pane (2→1) doesn't break scrolling in the surviving pane

🤖 Generated with [Claude Code](https://claude.com/claude-code)