### PR TITLE
feat: Add worktree support for scheduled agents

### DIFF
--- a/crates/pu-cli/assets/SKILL.md
+++ b/crates/pu-cli/assets/SKILL.md
@@ -85,16 +85,29 @@ pu schedule list                   # list all schedules
 pu schedule list --json            # machine-readable
 pu schedule show <name>            # show schedule details
 pu schedule show <name> --json     # machine-readable
-pu schedule create <name> \
-  --start-at "2026-03-07T14:00:00Z" \
-  --recurrence none \
+
+# Worktree spawn (default) — needs --name
+pu schedule create overnight-build \
+  --start-at "2026-03-07T22:30:00" \
+  --name overnight-build \
   --trigger inline-prompt \
-  --trigger-prompt "do the thing"  # one-shot scheduled agent
-pu schedule create <name> \
-  --start-at "2026-03-07T14:00:00Z" \
+  --trigger-prompt "build a feature"   # spawns in worktree pu/overnight-build
+
+# Root spawn — for read-only/cross-project tasks
+pu schedule create morning-status \
+  --start-at "2026-03-07T08:00:00" \
+  --root \
+  --trigger inline-prompt \
+  --trigger-prompt "scan commits"      # spawns in project root
+
+# Recurring with agent def
+pu schedule create nightly-review \
+  --start-at "2026-03-07T03:00:00" \
   --recurrence daily \
+  --root \
   --trigger agent-def \
-  --trigger-name my-agent          # recurring from saved agent def
+  --trigger-name security-review       # recurring root agent from saved def
+
 pu schedule enable <name>          # enable a disabled schedule
 pu schedule disable <name>         # disable without deleting
 pu schedule delete <name>          # remove a schedule
@@ -103,6 +116,8 @@ pu schedule delete <name>          # remove a schedule
 **Recurrence options**: `none` (one-shot), `hourly`, `daily`, `weekdays`, `weekly`, `monthly`.
 
 **Trigger types**: `inline-prompt` (with `--trigger-prompt`), `agent-def` (with `--trigger-name`), `swarm-def` (with `--trigger-name`).
+
+**Spawn mode**: By default, scheduled agents spawn into a worktree (requires `--name`). Use `--root` to spawn in the project root instead (for read-only or cross-project tasks).
 
 **Scope**: `--scope local` (default, project-level) or `--scope global`.
 

--- a/crates/pu-cli/src/commands/schedule.rs
+++ b/crates/pu-cli/src/commands/schedule.rs
@@ -30,10 +30,19 @@ pub async fn run_create(
     agent: &str,
     vars: Vec<String>,
     scope: &str,
+    root: bool,
+    agent_name: Option<String>,
     json: bool,
 ) -> Result<(), CliError> {
     daemon_ctrl::ensure_daemon(socket).await?;
     let project_root = commands::cwd_string()?;
+
+    // Validate: --name is required when not --root
+    if !root && agent_name.is_none() {
+        return Err(CliError::Other(
+            "--name is required when not using --root".into(),
+        ));
+    }
 
     let start_at_dt = parse_datetime(start_at)?;
 
@@ -77,6 +86,8 @@ pub async fn run_create(
             trigger,
             target: String::new(),
             scope: scope.to_string(),
+            root,
+            agent_name,
         },
     )
     .await?;

--- a/crates/pu-cli/src/main.rs
+++ b/crates/pu-cli/src/main.rs
@@ -400,6 +400,12 @@ enum ScheduleAction {
         /// Scope: local or global
         #[arg(long, default_value = "local")]
         scope: String,
+        /// Spawn as root agent (in project root, not a worktree)
+        #[arg(long)]
+        root: bool,
+        /// Worktree/branch name (required when not --root)
+        #[arg(long = "name")]
+        agent_name: Option<String>,
         /// Output as JSON
         #[arg(long)]
         json: bool,
@@ -605,6 +611,8 @@ async fn main() {
                 agent,
                 vars,
                 scope,
+                root,
+                agent_name,
                 json,
             } => {
                 commands::schedule::run_create(
@@ -618,6 +626,8 @@ async fn main() {
                     &agent,
                     vars,
                     &scope,
+                    root,
+                    agent_name,
                     json,
                 )
                 .await

--- a/crates/pu-cli/src/output.rs
+++ b/crates/pu-cli/src/output.rs
@@ -425,11 +425,17 @@ pub fn print_response(response: &Response, json_mode: bool) {
             next_run,
             trigger,
             scope,
+            root,
+            agent_name,
             ..
         } => {
             println!("{} ({})", name.bold(), scope.dimmed());
             println!("  Enabled:    {enabled}");
             println!("  Recurrence: {recurrence}");
+            println!("  Root:       {root}");
+            if let Some(an) = agent_name {
+                println!("  Agent name: {an}");
+            }
             println!("  Start at:   {}", start_at.format("%Y-%m-%d %H:%M UTC"));
             if let Some(nr) = next_run {
                 println!("  Next run:   {}", nr.format("%Y-%m-%d %H:%M UTC"));
@@ -813,6 +819,8 @@ mod tests {
                 project_root: "/test".into(),
                 target: String::new(),
                 scope: "local".into(),
+                root: true,
+                agent_name: None,
                 created_at: chrono::Utc::now(),
             }],
         };
@@ -840,6 +848,8 @@ mod tests {
             project_root: "/test".into(),
             target: String::new(),
             scope: "local".into(),
+            root: true,
+            agent_name: None,
             created_at: chrono::Utc::now(),
         };
         print_response(&resp, false);

--- a/crates/pu-core/src/protocol.rs
+++ b/crates/pu-core/src/protocol.rs
@@ -220,6 +220,10 @@ pub enum Request {
         #[serde(default)]
         target: String,
         scope: String,
+        #[serde(default = "crate::serde_defaults::default_true")]
+        root: bool,
+        #[serde(default)]
+        agent_name: Option<String>,
     },
     DeleteSchedule {
         project_root: String,
@@ -325,6 +329,10 @@ pub struct ScheduleInfo {
     pub project_root: String,
     pub target: String,
     pub scope: String,
+    #[serde(default = "crate::serde_defaults::default_true")]
+    pub root: bool,
+    #[serde(default)]
+    pub agent_name: Option<String>,
     pub created_at: DateTime<Utc>,
 }
 
@@ -492,6 +500,10 @@ pub enum Response {
         project_root: String,
         target: String,
         scope: String,
+        #[serde(default = "crate::serde_defaults::default_true")]
+        root: bool,
+        #[serde(default)]
+        agent_name: Option<String>,
         created_at: DateTime<Utc>,
     },
     Ok,
@@ -1812,6 +1824,8 @@ mod tests {
             },
             target: String::new(),
             scope: "local".into(),
+            root: true,
+            agent_name: None,
         };
         let json = serde_json::to_string(&req).unwrap();
         let parsed: Request = serde_json::from_str(&json).unwrap();
@@ -1887,6 +1901,8 @@ mod tests {
                 project_root: "/test".into(),
                 target: String::new(),
                 scope: "local".into(),
+                root: true,
+                agent_name: None,
                 created_at: Utc::now(),
             }],
         };
@@ -1916,6 +1932,8 @@ mod tests {
             project_root: "/test".into(),
             target: String::new(),
             scope: "local".into(),
+            root: false,
+            agent_name: Some("overnight-build".into()),
             created_at: Utc::now(),
         };
         let json = serde_json::to_string(&resp).unwrap();

--- a/crates/pu-core/src/schedule_def.rs
+++ b/crates/pu-core/src/schedule_def.rs
@@ -58,6 +58,12 @@ pub struct ScheduleDef {
     pub project_root: String,
     #[serde(default)]
     pub target: String,
+    /// Whether the scheduled agent spawns in the project root (true) or a worktree (false)
+    #[serde(default = "crate::serde_defaults::default_true")]
+    pub root: bool,
+    /// Worktree/branch name when `root` is false
+    #[serde(default)]
+    pub agent_name: Option<String>,
     /// "local" or "global" — set at load time, not serialized
     #[serde(skip)]
     pub scope: String,
@@ -308,6 +314,8 @@ mod tests {
             trigger: make_trigger(),
             project_root: "/projects/myapp".to_string(),
             target: String::new(),
+            root: true,
+            agent_name: None,
             scope: String::new(),
             created_at: Utc::now(),
         }
@@ -354,6 +362,32 @@ created_at: "2025-06-01T00:00:00Z"
         assert_eq!(def.recurrence, Recurrence::None); // default none
         assert_eq!(def.target, ""); // default empty
         assert!(def.next_run.is_none()); // default none
+        assert!(def.root); // default true (backward compat)
+        assert!(def.agent_name.is_none()); // default none
+    }
+
+    #[test]
+    fn given_schedule_with_worktree_fields_should_round_trip() {
+        let yaml = r#"
+name: overnight-build
+start_at: "2025-06-01T22:30:00Z"
+trigger:
+  type: inline_prompt
+  prompt: "build a feature"
+project_root: /projects/myapp
+root: false
+agent_name: overnight-build
+created_at: "2025-06-01T00:00:00Z"
+"#;
+        let def: ScheduleDef = serde_yml::from_str(yaml).unwrap();
+        assert!(!def.root);
+        assert_eq!(def.agent_name.as_deref(), Some("overnight-build"));
+
+        // Round-trip through YAML
+        let serialized = serde_yml::to_string(&def).unwrap();
+        let reparsed: ScheduleDef = serde_yml::from_str(&serialized).unwrap();
+        assert!(!reparsed.root);
+        assert_eq!(reparsed.agent_name.as_deref(), Some("overnight-build"));
     }
 
     #[test]

--- a/crates/pu-engine/src/engine.rs
+++ b/crates/pu-engine/src/engine.rs
@@ -366,6 +366,8 @@ impl Engine {
                 trigger,
                 target,
                 scope,
+                root,
+                agent_name,
             } => {
                 self.handle_save_schedule(
                     &project_root,
@@ -376,6 +378,8 @@ impl Engine {
                     trigger,
                     &target,
                     &scope,
+                    root,
+                    agent_name,
                 )
                 .await
             }
@@ -2507,6 +2511,8 @@ impl Engine {
         trigger: ScheduleTriggerPayload,
         target: &str,
         scope: &str,
+        root: bool,
+        agent_name: Option<String>,
     ) -> Response {
         let dir = match Self::resolve_scope_dir(
             project_root,
@@ -2546,6 +2552,8 @@ impl Engine {
             trigger: Self::payload_to_trigger(&trigger),
             project_root: project_root.to_string(),
             target: target.to_string(),
+            root,
+            agent_name,
             scope: scope.to_string(),
             created_at: now,
         };
@@ -2681,6 +2689,8 @@ impl Engine {
             project_root: d.project_root,
             target: d.target,
             scope: d.scope,
+            root: d.root,
+            agent_name: d.agent_name,
             created_at: d.created_at,
         }
     }
@@ -2696,6 +2706,8 @@ impl Engine {
             project_root: d.project_root,
             target: d.target,
             scope: d.scope,
+            root: d.root,
+            agent_name: d.agent_name,
             created_at: d.created_at,
         }
     }
@@ -2814,12 +2826,12 @@ impl Engine {
             pu_core::schedule_def::ScheduleTrigger::AgentDef { name } => {
                 // Resolve agent def to get its type and prompt
                 let pr = schedule.project_root.clone();
-                let root = Path::new(&pr);
-                if let Some(def) = pu_core::agent_def::find_agent_def(root, name) {
+                let project_path = Path::new(&pr);
+                if let Some(def) = pu_core::agent_def::find_agent_def(project_path, name) {
                     let prompt = if let Some(ref ip) = def.inline_prompt {
                         ip.clone()
                     } else if let Some(ref tpl_name) = def.template {
-                        pu_core::template::find_template(root, tpl_name)
+                        pu_core::template::find_template(project_path, tpl_name)
                             .map(|t| t.body)
                             .unwrap_or_else(|| {
                                 format!("Scheduled: agent def '{name}' (template not found)")
@@ -2831,9 +2843,9 @@ impl Engine {
                         project_root: pr,
                         prompt,
                         agent: def.agent_type,
-                        name: None,
+                        name: schedule.agent_name.clone(),
                         base: None,
-                        root: true,
+                        root: schedule.root,
                         worktree: None,
                     })
                     .await
@@ -2857,9 +2869,9 @@ impl Engine {
                     project_root: schedule.project_root.clone(),
                     prompt: prompt.clone(),
                     agent: agent.clone(),
-                    name: None,
+                    name: schedule.agent_name.clone(),
                     base: None,
-                    root: true,
+                    root: schedule.root,
                     worktree: None,
                 })
                 .await


### PR DESCRIPTION
## Summary

- Adds `root` and `agent_name` fields to `ScheduleDef`, protocol (`SaveSchedule`, `ScheduleInfo`, `ScheduleDetail`), with `default: true` for backward compatibility
- Adds `--root` flag and `--name <worktree>` arg to `pu schedule create` — default is worktree mode (requires `--name`), `--root` opts into root-agent spawning
- Updates `fire_schedule()` to pass `schedule.root` and `schedule.agent_name` to `Spawn` instead of hardcoding `root: true`
- Updates SKILL.md with examples for both modes

## Test plan

- [x] `cargo test -p pu-core -- schedule` — all schedule tests pass (including new `given_schedule_with_worktree_fields_should_round_trip`)
- [x] `cargo test -p pu-cli -- schedule` — all 7 CLI schedule tests pass
- [x] Full build compiles cleanly
- [ ] Manual: create schedule with `--name test-wt`, verify `pu schedule show` displays `root: false`
- [ ] Manual: create schedule with `--root`, confirm backward-compatible root spawning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added `--root` flag to enable root-spawning for read-only or cross-project agent tasks.
  * Worktree spawn mode (default) now requires the `--name` parameter for agent identification.

* **Documentation**
  * Updated schedule creation examples with expanded coverage of root spawn, worktree spawn, and trigger configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->