### PR TITLE
fix: Consecutive Cmd+N no longer spawns agent in wrong project

### DIFF
--- a/apps/purepoint-macos/purepoint-macos/State/AppState.swift
+++ b/apps/purepoint-macos/purepoint-macos/State/AppState.swift
@@ -82,9 +82,13 @@ final class AppState {
 
         switch selection {
         case .agent(let id), .terminal(let id):
-            activeProjectRoot = projectState(forAgentId: id)?.projectRoot
+            if let root = projectState(forAgentId: id)?.projectRoot {
+                activeProjectRoot = root
+            }
         case .worktree(let id):
-            activeProjectRoot = projectState(forWorktreeId: id)?.projectRoot
+            if let root = projectState(forWorktreeId: id)?.projectRoot {
+                activeProjectRoot = root
+            }
         case .project(let root):
             activeProjectRoot = root
         case nil, .nav:

--- a/apps/purepoint-macos/purepoint-macos/State/ProjectState.swift
+++ b/apps/purepoint-macos/purepoint-macos/State/ProjectState.swift
@@ -162,6 +162,7 @@ final class ProjectState: Identifiable {
             )
         ) { response in
             if case .spawnResult(_, let agentId, _) = response {
+                self.appState?.activeProjectRoot = self.projectRoot
                 self.appState?.pendingSelectAgentId = agentId
             }
         }
@@ -196,6 +197,7 @@ final class ProjectState: Identifiable {
     func createWorktree(name: String?) {
         sendDaemonRequest(.createWorktree(projectRoot: projectRoot, name: name)) { response in
             if case .createWorktreeResult(let worktreeId) = response {
+                self.appState?.activeProjectRoot = self.projectRoot
                 self.appState?.pendingSelectWorktreeId = worktreeId
             }
         }

--- a/apps/purepoint-macos/purepoint-macos/State/ProjectState.swift
+++ b/apps/purepoint-macos/purepoint-macos/State/ProjectState.swift
@@ -162,7 +162,9 @@ final class ProjectState: Identifiable {
             )
         ) { response in
             if case .spawnResult(_, let agentId, _) = response {
-                self.appState?.activeProjectRoot = self.projectRoot
+                if self.appState?.projectState(forRoot: self.projectRoot) != nil {
+                    self.appState?.activeProjectRoot = self.projectRoot
+                }
                 self.appState?.pendingSelectAgentId = agentId
             }
         }
@@ -197,7 +199,9 @@ final class ProjectState: Identifiable {
     func createWorktree(name: String?) {
         sendDaemonRequest(.createWorktree(projectRoot: projectRoot, name: name)) { response in
             if case .createWorktreeResult(let worktreeId) = response {
-                self.appState?.activeProjectRoot = self.projectRoot
+                if self.appState?.projectState(forRoot: self.projectRoot) != nil {
+                    self.appState?.activeProjectRoot = self.projectRoot
+                }
                 self.appState?.pendingSelectWorktreeId = worktreeId
             }
         }

--- a/apps/purepoint-macos/purepoint-macosTests/ActiveProjectRoutingTests.swift
+++ b/apps/purepoint-macos/purepoint-macosTests/ActiveProjectRoutingTests.swift
@@ -111,6 +111,26 @@ struct ActiveProjectRoutingTests {
         #expect(state.activeSidebarSelection == .agent("a1"))
     }
 
+    @Test func unknownWorktreeIdPreservesActiveProjectRoot() {
+        let state = AppState(service: StubWorkspaceService())
+        state.projects = [makeProject(root: "/a"), makeProject(root: "/b")]
+        state.activeProjectRoot = "/a"
+
+        state.updateActiveProject(for: .worktree("nonexistent"))
+
+        #expect(state.activeProjectRoot == "/a")
+    }
+
+    @Test func unknownAgentIdPreservesActiveProjectRoot() {
+        let state = AppState(service: StubWorkspaceService())
+        state.projects = [makeProject(root: "/a"), makeProject(root: "/b")]
+        state.activeProjectRoot = "/a"
+
+        state.updateActiveProject(for: .agent("nonexistent"))
+
+        #expect(state.activeProjectRoot == "/a")
+    }
+
     @Test func worktreeAgentTerminalRoutesThroughWorktree() {
         let state = AppState(service: StubWorkspaceService())
         state.projects = [


### PR DESCRIPTION
## Summary

- Guard `updateActiveProject` against nil lookups so `activeProjectRoot` is preserved when the entity isn't in the data model yet (daemon responds before manifest refresh)
- Set `activeProjectRoot` explicitly in `createWorktree`/`createAgent` callbacks since the `ProjectState` already knows the correct project root
- Guard callbacks against removed projects — only set `activeProjectRoot` when `projectState(forRoot:)` confirms the project still exists
- Add 2 regression tests for unknown worktree/agent ID preservation

## Test plan

- [ ] Run `ActiveProjectRoutingTests` in Xcode — all 10 tests pass (8 existing + 2 new)
- [ ] Manual: open two projects, Cmd+N → create worktree in project 2, immediately Cmd+N → spawn agent — agent should appear in project 2's worktree (not project 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented active project from being cleared when operations reference unknown agents or worktrees.
  * Ensure active project is set reliably when creating agents or worktrees.

* **Tests**
  * Added tests verifying unknown agent/worktree IDs do not change the active project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->